### PR TITLE
Fix:vote re-entrancy

### DIFF
--- a/contracts/veVelvet.sol
+++ b/contracts/veVelvet.sol
@@ -221,9 +221,10 @@ contract veVelvet is
         }
         locks[account].pop();
 
+        _transferVotingUnits(account, address(0), amount);
+
         IERC20(baseToken).safeTransfer(account, amount);
         emit Withdraw(account, id, amount);
-        _transferVotingUnits(account, address(0), amount);
     }
 
     function toggleAutoRenew(uint256 id) external nonReentrant {


### PR DESCRIPTION
At the end of a withdrawal the contract calls _transferVotingUnits(). This will look up the delegatee of the account and reduce their voting units.

However, the delegate() function (available through VotesUpgradable) is not protected with a nonReentrant modifier. Similarly, the implementation of _getVotingUnits in veVevet does not prevent reentrant calls.

As a result an attacker can potentially leverage the external call (safeTransfer) to change delegatee before the _transferVotingUnits call. A change of delegatees executed during the safeTransfer would use a state where the lock and thus _getVotingUnits() result is already updated. So it would not attempt to move the to be burned voting units. The consecutive _transferVotingUnits() to address zero would then remove voting units from the new delegatee even though they never received them.

In effect the attacker will have transferred amount tokens from the new delegatee to the old delegatee.

This attack is possible when baseToken performs external calls, note however that the scope of this audit is limited to veVelvet.